### PR TITLE
Bump to 2.2.19

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,11 @@ on:
       - 'master'
   push:
     branches:
+      - 'feature*'
+      - 'feature/*'
       - 'feature_*'
+      - 'hotfix*'
+      - 'hotfix/*'
       - 'master'
   schedule:
     - cron: '0 4 * * *'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,10 +53,10 @@ jobs:
       with:
         path: 'darkwizard242.vagrant'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         path: 'darkwizard242.vagrant'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 vagrant_app: vagrant
-vagrant_version: 2.2.18
+vagrant_version: 2.2.19
 vagrant_osarch: linux_amd64
 vagrant_dl_url: https://releases.hashicorp.com
 vagrant_dl_loc: /tmp
@@ -28,7 +28,7 @@ vagrant_bin_path: /usr/local/bin
 Variable         | Value (default)                  | Description
 ---------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------
 vagrant_app      | vagrant                          | Defines the app to install i.e. **vagrant**
-vagrant_version  | 2.2.18                           | Defined to dynamically fetch the desired version to install. Defaults to: **2.2.18**
+vagrant_version  | 2.2.19                           | Defined to dynamically fetch the desired version to install. Defaults to: **2.2.19**
 vagrant_osarch   | linux_amd64                      | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux_amd64**
 vagrant_dl_url   | <https://releases.hashicorp.com> | Defines URL to download the vagrant binary from.
 vagrant_dl_loc   | /tmp                             | Defined to dynamically set where to place the binary archive for `vagrant` temporarily. Defaults to: **/tmp**

--- a/README.md
+++ b/README.md
@@ -74,4 +74,4 @@ For customizing behavior of role (i.e. placing binary of **vagrant** package in 
 
 ## Author Information
 
-This role was created by [Ali Muhammad](https://www.linkedin.com/in/ali-muhammad-759791130/).
+This role was created by [Ali Muhammad](https://www.alimuhammad.dev/).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for vagrant
 
 vagrant_app: vagrant
-vagrant_version: 2.2.18
+vagrant_version: 2.2.19
 vagrant_osarch: linux_amd64
 vagrant_dl_url: https://releases.hashicorp.com
 vagrant_dl_loc: /tmp


### PR DESCRIPTION
- Bump vagrant version to **2.2.19**
- Bump python to 3.10.0 in `build-and-test` and `release` github actions workflows.
- Add additional push branches to `build-and-test` github action workflow